### PR TITLE
Correcting  --titlefont parameter in helpText

### DIFF
--- a/dialog/extras/helpText.swift
+++ b/dialog/extras/helpText.swift
@@ -32,7 +32,7 @@ var helpText = """
     
                         size=<float>              - accepts any float value.
     
-                        font=<fontname>           - accepts a font name or family
+                        name=<fontname>           - accepts a font name or family
                                                     list of available names can be determined with --\(cloptions.listFonts.long)
 
                         weight=[thin | light | regular | medium | heavy | bold]

--- a/dialog/extras/helpText.swift
+++ b/dialog/extras/helpText.swift
@@ -64,7 +64,7 @@ var helpText = """
     
                         size=<float>              - accepts any float value.
     
-                        font=<fontname>           - accepts a font name or family
+                        name=<fontname>           - accepts a font name or family
                                                     list of available names can be determined with --\(cloptions.listFonts.long)
 
                         weight=[thin | light | regular | medium | heavy | bold]


### PR DESCRIPTION
incorrectly listed `font=<fontname>` rather than `name=<fontname>`